### PR TITLE
Add recurse-submodules option to install

### DIFF
--- a/install.md
+++ b/install.md
@@ -28,7 +28,7 @@ be useful if you want to try an unstable or in-development version of **WHAD**.
 It is recommended to install **WHAD** in a virtual environment:
 
 ```
-git clone https://github.com/whad-team/whad-client.git
+git clone https://github.com/whad-team/whad-client.git --recurse-submodules
 cd whad-client
 python -m venv my_venv
 . /my_venv/bin/activate


### PR DESCRIPTION
`--recurse-submodules` option is present in WHAD rst documentation, but absent from this website. Less reduce user confusions by adding the option here, which is needed to have CLUES JSON submodule.